### PR TITLE
move after deploy hook into app loop

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -207,8 +207,9 @@ namespace :heroku do
   task :deploy, [:commit] => [:before_deploy] do |t, args|
     each_heroku_app do |stage|
       stage.deploy(args.commit)
+      Rake::Task["heroku:deploy:after"].invoke(stage)
+      Rake::Task["heroku:deploy:after"].reenable
     end
-    Rake::Task[:after_deploy].execute
   end
 
   namespace :deploy do
@@ -216,8 +217,9 @@ namespace :heroku do
     task :force, [:commit] => [:before_deploy] do |t, args|
       each_heroku_app do |stage|
         stage.deploy(args.commit, :force)
+        Rake::Task["heroku:deploy:after"].invoke(stage)
+        Rake::Task["heroku:deploy:after"].reenable
       end
-      Rake::Task[:after_deploy].execute
     end
 
     desc "Callback before deploys"
@@ -226,7 +228,7 @@ namespace :heroku do
 
     desc "Callback after deploys"
     task :after do
-  end
+    end
 
   end
 


### PR DESCRIPTION
This change didn't break tests and is what I wanted, so I figured that I'd submit it as a PR.

This moves the `after_deploy` hook into the `each_heroku_app` loop which seems like where it should be to me. The `stage` is passed into the `after` task as an argument named `stage`.