### PR TITLE
Add exit code flag to Heroku command

### DIFF
--- a/lib/heroku_san/api.rb
+++ b/lib/heroku_san/api.rb
@@ -9,7 +9,7 @@ module HerokuSan
     def sh(app, *command)
       preflight_check_for_cli
 
-      cmd = (command + ['--app', app]).compact
+      cmd = (command + ['--app', app, "--exit-code"]).compact
 
       show_command = cmd.join(' ')
       $stderr.puts show_command if @debug


### PR DESCRIPTION
Our deploys have been succeeding even when tasks such as migrations fail miserably; it turns out that `heroku-exit-status` doesn't work with the newer Heroku toolbelts. Heroku itself now has an `--exit-status` flag that does what is expected (https://github.com/glenngillen/heroku-exit-status/issues/8).